### PR TITLE
Setup Sonar check

### DIFF
--- a/.github/workflows/bring-ci.yml
+++ b/.github/workflows/bring-ci.yml
@@ -16,8 +16,15 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
           cache: maven
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
       - name: Build
         run: mvn package -DskipTests=true
       - name: Test
         # Skips all steps except test
         run: mvn surefire:test
+      - name: Generate report for SonarCloud
+        run: mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=hoverla-bobocode_Bring
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
         <junit.version>5.8.2</junit.version>
+        <sonar.organization>hoverla-bobocode</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Description:
Adds another step in CI to generate reports to SonarCloud. 
Then SonarCloud analyze job runs automatically and fails branch status if something doesn't match default sonar rules.
It also includes test coverage check, which is 80% by default.
### Ticket: https://trello.com/c/S9CUMvp6, https://trello.com/c/pDnmSRH
### Testing notes:
Created a testing branch where failed test is imitated. The branch status is failed accordingly.
https://github.com/hoverla-bobocode/Bring/tree/test-sonar-and-coverage
 
 
<img width="846" alt="image" src="https://user-images.githubusercontent.com/26688721/179031133-51d51bf0-7181-4f67-b39c-f484649e6928.png">
<img width="1650" alt="image" src="https://user-images.githubusercontent.com/26688721/179031209-202677f3-4ccd-41ff-bb2c-80931f5cb469.png">

