### PR TITLE
Implement BeanInitializer

### DIFF
--- a/codestyle/bring-code-scheme.xml
+++ b/codestyle/bring-code-scheme.xml
@@ -1,0 +1,6 @@
+<code_scheme name="Default" version="173">
+  <JavaCodeStyleSettings>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
+  </JavaCodeStyleSettings>
+</code_scheme>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.6.1</mockito.version>
         <assertj.version>3.23.1</assertj.version>
+        <guava.version>31.1-jre</guava.version>
     </properties>
 
     <dependencies>
@@ -39,6 +40,11 @@
             <version>${lombok.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
@@ -54,6 +60,7 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/bobocode/hoverla/bring/context/BeanInitializer.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/BeanInitializer.java
@@ -1,13 +1,38 @@
 package com.bobocode.hoverla.bring.context;
 
-import java.util.Map;
+import com.google.common.collect.Table;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collection;
+
+/**
+ * Class, responsible for triggering bean initialization.
+ * <br>
+ * Its main aim is to pass all dependencies of a particular {@link BeanDefinition}
+ * to its {@link BeanDefinition#instance(BeanDefinition...)} method.
+ */
+@Slf4j
 public class BeanInitializer {
 
-    /**
-     * Instantiates beans and injects dependencies in them
-     */
-    void initialize(Map<String, BeanDefinition> beanDefinitions) {
 
+    /**
+     * Triggers instantiation of all beans by passing their required dependencies.
+     * @param beanDefinitionsTable {@link Table} with all {@link BeanDefinition} objects handled by current context.
+     */
+    public void initialize(Table<String, Class<?>, BeanDefinition> beanDefinitionsTable) {
+        log.debug("Bean initialization started");
+        Collection<BeanDefinition> beanDefinitions = beanDefinitionsTable.values();
+
+        for (BeanDefinition beanDefinition : beanDefinitions) {
+            log.trace("Resolving dependencies for bean definition: {} - {}", beanDefinition.name(), beanDefinition.type());
+            BeanDefinition[] beanDependencies = beanDefinition.dependencies()
+                    .entrySet()
+                    .stream()
+                    .map(keyPair -> beanDefinitionsTable.get(keyPair.getKey(), keyPair.getValue()))
+                    .toArray(BeanDefinition[]::new);
+
+            log.trace("Found {} dependencies", beanDependencies.length);
+            beanDefinition.instance(beanDependencies);
+        }
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/context/BeanInitializerTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/context/BeanInitializerTest.java
@@ -1,0 +1,82 @@
+package com.bobocode.hoverla.bring.context;
+
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BeanInitializerTest {
+
+    private static final String BD1 = "beanDef1";
+    private static final String BD2 = "beanDef2";
+    private static final String BD3 = "beanDef3";
+    private static final String BD4 = "beanDef4";
+
+    @Test
+    @DisplayName("Initialization test. Verifies that 'instance' method of BeanDefinition is called with correct dependencies")
+    void testInitialize() {
+        //Given
+        BeanDefinition beanDef1 = prepareDefinition(BD1, BD2, BD3);
+        BeanDefinition beanDef2 = prepareDefinition(BD2, BD3, BD4);
+        BeanDefinition beanDef3 = prepareDefinition(BD3, BD4);
+        BeanDefinition beanDef4 = prepareDefinition(BD4);
+
+        Table<String, Class<?>, BeanDefinition> beanDefinitionTable = ImmutableTable.<String, Class<?>, BeanDefinition>builder()
+                .put(Tables.immutableCell(beanDef1.name(), beanDef1.type(), beanDef1))
+                .put(Tables.immutableCell(beanDef2.name(), beanDef2.type(), beanDef2))
+                .put(Tables.immutableCell(beanDef3.name(), beanDef3.type(), beanDef3))
+                .put(Tables.immutableCell(beanDef4.name(), beanDef4.type(), beanDef4))
+                .build();
+
+        Map<BeanDefinition, BeanDefinition[]> expectedInvocationArgs = Map.of(
+                beanDef1, new BeanDefinition[]{beanDef2, beanDef3},
+                beanDef2, new BeanDefinition[]{beanDef3, beanDef4},
+                beanDef3, new BeanDefinition[]{beanDef4},
+                beanDef4, new BeanDefinition[0]
+        );
+
+        BeanInitializer beanInitializer = new BeanInitializer();
+
+        //When
+        beanInitializer.initialize(beanDefinitionTable);
+
+        //Then
+        for (BeanDefinition beanDefinition : beanDefinitionTable.values()) {
+            ArgumentCaptor<BeanDefinition> definitionCaptor = ArgumentCaptor.forClass(BeanDefinition.class);
+
+            verify(beanDefinition).instance(definitionCaptor.capture());
+
+            BeanDefinition[] expectedDependencies = expectedInvocationArgs.get(beanDefinition);
+            List<BeanDefinition> actualDependencies = definitionCaptor.getAllValues();
+
+            assertThat(actualDependencies).hasSize(expectedDependencies.length);
+            assertThat(actualDependencies).containsExactlyInAnyOrder(expectedDependencies);
+        }
+    }
+
+    private static BeanDefinition prepareDefinition(String beanDefinitionName, String... dependencyNames) {
+        BeanDefinition beanDefinition = mock(BeanDefinition.class);
+        doReturn(BeanDefinition.class).when(beanDefinition).type();
+        when(beanDefinition.name()).thenReturn(beanDefinitionName);
+
+        Map<String, Class<?>> dependencies = new HashMap<>();
+        for (var name : dependencyNames) {
+            dependencies.put(name, BeanDefinition.class);
+        }
+        when(beanDefinition.dependencies()).thenReturn(dependencies);
+
+        return beanDefinition;
+    }
+}


### PR DESCRIPTION
## Desctiprion:
`BeanInitializer` is a class that is responsible for triggering bean initialization. It does that by fetching all bean dependencies from the bean definition container and passing those into `BeanDefinition.instance()` method.
### Changes:

1. Implement BeanInitializer, based on Google Guava Table. 
2. Add a code style folder, where the latest code scheme .xml file is stored.

## Ticket: https://trello.com/c/Z96MzpAi