### PR TITLE
Generate coverage reports using JaCoCo Maven plugin

### DIFF
--- a/.github/workflows/bring-ci.yml
+++ b/.github/workflows/bring-ci.yml
@@ -20,10 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Build
         run: mvn package -DskipTests=true
-      - name: Test
-        # Skips all steps except test
-        run: mvn surefire:test
-      - name: Generate report for SonarCloud
+      - name: Test and Generate Sonar Report
         run: mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=hoverla-bobocode_Bring
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
+        <maven.jacoco.plugin.version>0.8.7</maven.jacoco.plugin.version>
         <logback.version>1.2.11</logback.version>
         <lombok.version>1.18.24</lombok.version>
-        <slf4j.version>1.7.36</slf4j.version>
         <junit.version>5.8.2</junit.version>
         <sonar.organization>hoverla-bobocode</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -37,11 +37,6 @@
             <version>${lombok.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>
@@ -50,15 +45,31 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven.surefire.plugin.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${maven.jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
### Description:
For SonarCloud we must generate reports for coverage manually, so JaCoCo plugin is added to fix the issue. 
Also, removed sff4j-api dependency, because it's taken transitively from logback.
### Ticket: https://trello.com/c/ODJAPQv1

### Testing notes:
Here's a branch with tests that shows 100% coverage in SonarCloud reports
https://github.com/hoverla-bobocode/Bring/tree/test-coverage