### PR TITLE
Implement ConfigBasedBeanDefinition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,15 +9,17 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>17</java.version>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
         <maven.jacoco.plugin.version>0.8.7</maven.jacoco.plugin.version>
+        <sonar.organization>hoverla-bobocode</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <logback.version>1.2.11</logback.version>
         <lombok.version>1.18.24</lombok.version>
         <junit.version>5.8.2</junit.version>
-        <sonar.organization>hoverla-bobocode</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <mockito.version>4.6.1</mockito.version>
+        <assertj.version>3.23.1</assertj.version>
     </properties>
 
     <dependencies>
@@ -42,10 +44,34 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <compilerArgs>
+                        <!-- to preserve method parameter names after compilation -->
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/com/bobocode/hoverla/bring/annotation/Bean.java
+++ b/src/main/java/com/bobocode/hoverla/bring/annotation/Bean.java
@@ -9,8 +9,19 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation which is used to mark types as beans in order to be scanned by {@link ApplicationContext}
+ * <pre>
+ * Usage with classes:
+ * {@code @Bean(name = "beanName")
+ * class MyBean {
+ *
+ * }}
+ * Having such class in a package for bean scanning will cause {@link ApplicationContext} to
+ * scan this class and create a bean out of it
+ *
+ * Usage with configuration bean classes see in {@link Configuration}
+ * </pre>
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Bean {
 

--- a/src/main/java/com/bobocode/hoverla/bring/annotation/Configuration.java
+++ b/src/main/java/com/bobocode/hoverla/bring/annotation/Configuration.java
@@ -1,0 +1,29 @@
+package com.bobocode.hoverla.bring.annotation;
+
+import com.bobocode.hoverla.bring.context.ApplicationContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to mark classes that will be treated as Java Configuration bean classes.
+ *
+ * <pre>
+ * Usage:
+ * {@code @Configuration
+ * class MyBeanConfiguration {
+ *     @Bean
+ *     public String myBean() {
+ *         return "beanInstance";
+ *     }
+ * }}
+ * </pre>
+ * Having this class in a package for bean scanning will cause {@link ApplicationContext} to
+ * scan this class and create beans from methods that marked as {@link Bean}
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Configuration {
+}

--- a/src/main/java/com/bobocode/hoverla/bring/annotation/Qualifier.java
+++ b/src/main/java/com/bobocode/hoverla/bring/annotation/Qualifier.java
@@ -1,0 +1,21 @@
+package com.bobocode.hoverla.bring.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to specify bean name. Used only for parameters.
+ * Name specified in {@link Qualifier} takes precedence over other name specifications,
+ * so that parameter marked with {@link Qualifier} will always indicate bean with the name
+ * taken from {@link Qualifier#value()}
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Qualifier {
+    /**
+     * Bean name, required to specify
+     */
+    String value();
+}

--- a/src/main/java/com/bobocode/hoverla/bring/context/BeanDefinition.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/BeanDefinition.java
@@ -1,13 +1,37 @@
 package com.bobocode.hoverla.bring.context;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Wraps all necessary bean information, encapsulates bean creation logic (this logic can be seperated in future)
  */
 public interface BeanDefinition {
+    /**
+     * Returns bean name
+     * @return bean name
+     */
     String name();
+
+    /**
+     * Returns bean instance type
+     * @return bean instance type
+     */
     Class<?> type();
-    List<String> dependenciesNames();
+
+    /**
+     * Returns bean dependencies that are required for its instantiation in a format of Map where key
+     * is dependency's name and value is dependencies type
+     * @return bean dependencies map
+     */
+    Map<String, Class<?>> dependencies();
+
+    /**
+     * Instantiates bean using all necessary information encapsulated within.
+     * Requires bean definition which are treated as dependencies to be passed as arguments.
+     * If arguments don't match the actual required dependencies, the exception will be thrown.
+     *
+     * @param dependencies bean definitions that are treated as required dependencies for this bean instantiation
+     * @return bean instance
+     */
     Object instance(BeanDefinition... dependencies);
 }

--- a/src/main/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinition.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinition.java
@@ -1,0 +1,166 @@
+package com.bobocode.hoverla.bring.context;
+
+import com.bobocode.hoverla.bring.annotation.Bean;
+import com.bobocode.hoverla.bring.annotation.Configuration;
+import com.bobocode.hoverla.bring.annotation.Qualifier;
+import com.bobocode.hoverla.bring.exception.BeanDefinitionConstructionException;
+import com.bobocode.hoverla.bring.exception.BeanInstanceCreationException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Java Configuration-based bean definition. Requires instance of class marked with {@link Configuration} instance
+ * and method withing it marked with {@link Bean} that represents this bean initialization point.
+ */
+@Slf4j
+public class ConfigBasedBeanDefinition implements BeanDefinition {
+
+    private final Object configInstance;
+    private final Method beanMethod;
+    private final String name;
+    private final Class<?> type;
+    private final Map<String, Class<?>> dependencies;
+    private Object instance;
+
+    /**
+     * During execution doesn't instantiate target bean,
+     * but parses all info such as name, type, dependencies etc. and preserves this info to be used
+     *
+     * @param configInstance instance of a class marked as {@link Configuration} that contains method representing target bean
+     * @param beanMethod     method that represents target bean and is used to instantiate target bean
+     * @throws BeanDefinitionConstructionException when config class of the instance passed is not marked as {@link Configuration}
+     *                                             or bean method is not marked as {@link Bean}
+     * @throws NullPointerException                when any of arguments passed is null
+     */
+    public ConfigBasedBeanDefinition(Object configInstance, Method beanMethod) {
+        validate(configInstance, beanMethod);
+
+        log.debug("Creating {} from method '{}'", ConfigBasedBeanDefinition.class.getSimpleName(), beanMethod);
+        this.configInstance = configInstance;
+        this.beanMethod = beanMethod;
+
+        this.name = getName(beanMethod);
+        log.trace("Bean name is '{}'", name);
+
+        this.type = getType(beanMethod);
+        log.trace("'{}' bean type is '{}'", name, type);
+
+        this.dependencies = getDependencies(beanMethod);
+        log.trace("'{}' bean dependencies are {}", name, dependencies);
+    }
+
+    private static void validate(Object configInstance, Method method) {
+        log.debug("Validating arguments passed to create ConfigBased");
+        Objects.requireNonNull(configInstance, "Configuration class instance is null");
+        Objects.requireNonNull(method, "Configuration method to create bean is null");
+
+        checkClassMarkedAsConfig(configInstance);
+        checkMethodMarkedAsBean(method);
+    }
+
+    private static void checkClassMarkedAsConfig(Object configInstance) {
+        if (!configInstance.getClass().isAnnotationPresent(Configuration.class)) {
+            throw new BeanDefinitionConstructionException(
+                    "Configuration class instance passed is not marked as @%s".formatted(Configuration.class.getSimpleName())
+            );
+        }
+    }
+
+    private static void checkMethodMarkedAsBean(Method method) {
+        if (!method.isAnnotationPresent(Bean.class)) {
+            throw new BeanDefinitionConstructionException(
+                    "Configuration method to create bean is not marked as @%s".formatted(Bean.class.getSimpleName())
+            );
+        }
+    }
+
+    private static String getName(Method beanMethod) {
+        Bean annotation = beanMethod.getAnnotation(Bean.class);
+        String beanName = annotation.name();
+        if (beanName.isEmpty()) {
+            return beanMethod.getName();
+        }
+        return beanName;
+    }
+
+    private static Class<?> getType(Method beanMethod) {
+        return beanMethod.getReturnType();
+    }
+
+    private static Map<String, Class<?>> getDependencies(Method beanMethod) {
+        return Arrays.stream(beanMethod.getParameters())
+                     .collect(toMap(ConfigBasedBeanDefinition::getParameterName, Parameter::getType));
+    }
+
+    private static String getParameterName(Parameter parameter) {
+        if (parameter.isAnnotationPresent(Qualifier.class)) {
+            return parameter.getAnnotation(Qualifier.class).value();
+        }
+        return parameter.getName();
+    }
+
+    /**
+     * @return name of bean which is either equals to target bean method name
+     * or to name specified in {@link Bean} annotation
+     */
+    @Override
+    public String name() {
+        return name;
+    }
+
+    /**
+     * @return target bean method return type
+     */
+    @Override
+    public Class<?> type() {
+        return type;
+    }
+
+    /**
+     * @return dependencies map where keys are target bean method parameters name, and
+     * values are parameters types
+     */
+    @Override
+    public Map<String, Class<?>> dependencies() {
+        return dependencies;
+    }
+
+    /**
+     * Lazily initializes bean on the first call. After it happened further calls return a cached instance.
+     */
+    @Override
+    public Object instance(BeanDefinition... dependencies) {
+        if (instance != null) {
+            log.debug("Getting existing '{}' bean instance", name);
+            return instance;
+        }
+        return createInstance(dependencies);
+    }
+
+    private Object createInstance(BeanDefinition... dependencies) {
+        try {
+            log.debug("Initializing '{}' bean instance", name);
+            instance = getInstance(dependencies);
+            log.debug("'{}' bean was instantiated", name);
+            return instance;
+
+        } catch (Exception e) {
+            throw new BeanInstanceCreationException("'%s' bean can't be instantiated".formatted(name), e);
+        }
+    }
+
+    private Object getInstance(BeanDefinition... dependencies) throws InvocationTargetException, IllegalAccessException {
+        Object[] args = Arrays.stream(dependencies)
+                              .map(BeanDefinition::instance)
+                              .toArray();
+        return beanMethod.invoke(configInstance, args);
+    }
+}

--- a/src/main/java/com/bobocode/hoverla/bring/exception/BeanDefinitionConstructionException.java
+++ b/src/main/java/com/bobocode/hoverla/bring/exception/BeanDefinitionConstructionException.java
@@ -1,0 +1,10 @@
+package com.bobocode.hoverla.bring.exception;
+
+/**
+ * Thrown to indicate that bean definition cannot be constructed with passed arguments
+ */
+public class BeanDefinitionConstructionException extends RuntimeException {
+    public BeanDefinitionConstructionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bobocode/hoverla/bring/exception/BeanInstanceCreationException.java
+++ b/src/main/java/com/bobocode/hoverla/bring/exception/BeanInstanceCreationException.java
@@ -1,0 +1,11 @@
+package com.bobocode.hoverla.bring.exception;
+
+/**
+ * Thrown to indicate that bean definition failed to instantiate a bean
+ */
+public class BeanInstanceCreationException extends RuntimeException {
+
+    public BeanInstanceCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/bobocode/hoverla/bring/exception/NoSuchBeanException.java
+++ b/src/main/java/com/bobocode/hoverla/bring/exception/NoSuchBeanException.java
@@ -6,4 +6,7 @@ import com.bobocode.hoverla.bring.context.ApplicationContext;
  * Thrown to indicate that no bean with provided attributes is found in {@link ApplicationContext}
  */
 public class NoSuchBeanException extends RuntimeException {
+    public NoSuchBeanException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/test/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinitionTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinitionTest.java
@@ -1,0 +1,137 @@
+package com.bobocode.hoverla.bring.context;
+
+import com.bobocode.hoverla.bring.exception.BeanDefinitionConstructionException;
+import com.bobocode.hoverla.bring.exception.BeanInstanceCreationException;
+import com.bobocode.hoverla.bring.helper.BeanDefinitionAssert;
+import com.bobocode.hoverla.bring.testsubject.NotMarkedTestConfig;
+import com.bobocode.hoverla.bring.testsubject.TestBeanConfig;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConfigBasedBeanDefinitionTest {
+
+    private TestBeanConfig testBeanConfig;
+
+    @BeforeEach
+    void setUp() {
+        testBeanConfig = new TestBeanConfig();
+    }
+
+    @Test
+    @DisplayName("Bean name is taken from method name when there's no name specified in @Bean annotation")
+    void beanWithoutNameInAnnotation() throws NoSuchMethodException {
+        String methodName = "beanWithNoNameInAnnotation";
+        Method method = testBeanConfig.getClass().getMethod(methodName);
+
+        BeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);
+
+        BeanDefinitionAssert.assertThat(beanDefinition)
+                            .hasName(methodName);
+    }
+
+    @Test
+    @DisplayName("Bean name is taken from @Bean annotation")
+    void beanWithNameInAnnotation() throws NoSuchMethodException {
+        Method method = testBeanConfig.getClass().getMethod("beanWithNameInAnnotation");
+
+        BeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);
+
+        BeanDefinitionAssert.assertThat(beanDefinition)
+                            .hasName("beanName");
+    }
+
+    @Test
+    @DisplayName("Bean type matches method return type")
+    void beanTypeMatchesMethodReturnType() throws NoSuchMethodException {
+        Method method = testBeanConfig.getClass().getMethod("beanWithNameInAnnotation");
+
+        BeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);
+
+        BeanDefinitionAssert.assertThat(beanDefinition)
+                            .hasType(String.class);
+    }
+
+    @Test
+    @DisplayName("Bean dependencies match their parameter name or name taken from @Qualifier and type")
+    void beanWithDependencies() throws NoSuchMethodException {
+        String methodName = "beanWithDependencies";
+        Method method = testBeanConfig.getClass().getMethod(methodName, int.class, String.class);
+
+        BeanDefinition firstDependency = mock(BeanDefinition.class);
+        when(firstDependency.instance()).thenReturn(1);
+        BeanDefinition secondDependency = mock(BeanDefinition.class);
+        when(secondDependency.instance()).thenReturn("string");
+        Map<String, Class<?>> dependencies = Map.of("num", int.class, "testParamName", String.class);
+
+        BeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);
+
+        BeanDefinitionAssert.assertThat(beanDefinition)
+                            .hasDependencies(dependencies);
+    }
+
+    @Test
+    @DisplayName("Fails on missed dependencies passed when instance() is called")
+    void beanWithMissedDependencies() throws NoSuchMethodException {
+        String methodName = "beanWithDependencies";
+        Method method = testBeanConfig.getClass().getMethod(methodName, int.class, String.class);
+
+        BeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);
+
+        Assertions.assertThatThrownBy(beanDefinition::instance)
+                  .isInstanceOf(BeanInstanceCreationException.class)
+                  .hasMessageContaining("'beanWithDependencies' bean can't be instantiated")
+                  .hasStackTraceContaining("wrong number of arguments");
+    }
+
+    @Test
+    @DisplayName("Fails on configuration class not marked as @Configuration")
+    void configurationClassWithNoAnnotation() throws NoSuchMethodException {
+        NotMarkedTestConfig configInstance = new NotMarkedTestConfig();
+        Method method = configInstance.getClass().getMethod("bean");
+
+        Assertions.assertThatThrownBy(() -> new ConfigBasedBeanDefinition(configInstance, method))
+                  .isInstanceOf(BeanDefinitionConstructionException.class)
+                  .hasMessageContaining("Configuration class instance passed is not marked as @Configuration");
+    }
+
+    @Test
+    @DisplayName("Fails on method not marked as @Bean")
+    void methodNotMarkedAsBean() throws NoSuchMethodException {
+        Method method = testBeanConfig.getClass().getMethod("notBeanMethod");
+
+        Assertions.assertThatThrownBy(() -> new ConfigBasedBeanDefinition(testBeanConfig, method))
+                  .isInstanceOf(BeanDefinitionConstructionException.class)
+                  .hasMessageContaining("Configuration method to create bean is not marked as @Bean");
+    }
+
+    @Test
+    @DisplayName("Lazily instantiates beans")
+    void returnsBeanInstanceCache() throws NoSuchMethodException {
+        Method method = testBeanConfig.getClass().getMethod("beanWithNameInAnnotation");
+
+        ConfigBasedBeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);
+
+        // Has no instance before calling instance()
+        BeanDefinitionAssert.assertThat(beanDefinition)
+                            .hasFieldOrPropertyWithValue("instance", null);
+
+        Object instance = beanDefinition.instance();
+
+        // Has an instance after calling instance()
+         BeanDefinitionAssert.assertThat(beanDefinition)
+                            .hasFieldOrPropertyWithValue("instance", instance);
+
+        Object cachedInstance = beanDefinition.instance();
+
+        // Further instance() calls return the same object in memory
+        Assertions.assertThat(cachedInstance).isSameAs(instance);
+    }
+}

--- a/src/test/java/com/bobocode/hoverla/bring/helper/BeanDefinitionAssert.java
+++ b/src/test/java/com/bobocode/hoverla/bring/helper/BeanDefinitionAssert.java
@@ -1,0 +1,50 @@
+package com.bobocode.hoverla.bring.helper;
+
+import com.bobocode.hoverla.bring.context.BeanDefinition;
+import org.assertj.core.api.AbstractObjectAssert;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Class to help assert test cases related to BeanDefinition
+ */
+public class BeanDefinitionAssert extends AbstractObjectAssert<BeanDefinitionAssert, BeanDefinition> {
+    public BeanDefinitionAssert(BeanDefinition actual) {
+        super(actual, BeanDefinitionAssert.class);
+    }
+
+    public static BeanDefinitionAssert assertThat(BeanDefinition actual) {
+        return new BeanDefinitionAssert(actual);
+    }
+
+    public BeanDefinitionAssert hasName(String name) {
+        isNotNull();
+
+        if (!Objects.equals(actual.name(), name)) {
+            failWithMessage("Expected bean name to be '%s' but was '%s'", name, actual.name());
+        }
+
+        return this;
+    }
+
+    public BeanDefinitionAssert hasType(Class<?> type) {
+        isNotNull();
+
+        if (!Objects.equals(actual.type(), type)) {
+            failWithMessage("Expected bean type to be '%s' but was '%s'", type, actual.type());
+        }
+
+        return this;
+    }
+
+    public BeanDefinitionAssert hasDependencies(Map<String, Class<?>> dependencies) {
+        isNotNull();
+
+        if (!Objects.equals(actual.dependencies(), dependencies)) {
+            failWithMessage("Expected bean dependencies to be '%s' but was '%s'", dependencies, actual.dependencies());
+        }
+
+        return this;
+    }
+}

--- a/src/test/java/com/bobocode/hoverla/bring/testsubject/NotMarkedTestConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/testsubject/NotMarkedTestConfig.java
@@ -1,0 +1,10 @@
+package com.bobocode.hoverla.bring.testsubject;
+
+import com.bobocode.hoverla.bring.annotation.Bean;
+
+public class NotMarkedTestConfig {
+    @Bean
+    public String bean() {
+        return "instance";
+    }
+}

--- a/src/test/java/com/bobocode/hoverla/bring/testsubject/TestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/testsubject/TestBeanConfig.java
@@ -1,0 +1,28 @@
+package com.bobocode.hoverla.bring.testsubject;
+
+import com.bobocode.hoverla.bring.annotation.Bean;
+import com.bobocode.hoverla.bring.annotation.Configuration;
+import com.bobocode.hoverla.bring.annotation.Qualifier;
+
+@Configuration
+public class TestBeanConfig {
+
+    @Bean
+    public String beanWithNoNameInAnnotation() {
+        return "instance";
+    }
+
+    @Bean(name = "beanName")
+    public String beanWithNameInAnnotation() {
+        return "instance";
+    }
+
+    @Bean
+    public Integer beanWithDependencies(int num, @Qualifier("testParamName") String name) {
+        return 0;
+    }
+
+    public String notBeanMethod() {
+        return "not_bean";
+    }
+}


### PR DESCRIPTION
### Description:
**Changes**:
- Added implementation of BeanDefinition that can give information about bean defined in Java Bean Configuration class and lazily instantiate it.
- Added convenient BeanDefinitionAssert class to be use for assertions in test cases related to BeanDefinition
- Updated BeanDefinition interface to return map of dependencies
- Changed log level to info
- Configure compiler to leave method parameter names after compilation
- Updated documentation

### Ticket: https://trello.com/c/0hYSV2Fh