### PR TITLE
fixup CI workflow, add maven resources plugin with a default encoding

### DIFF
--- a/.github/workflows/bring-ci.yml
+++ b/.github/workflows/bring-ci.yml
@@ -1,27 +1,27 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: Bring CI
 
-on: [push]
+on: [ push ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # disable shallow clone in order not to skip Git history
+
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'corretto'
           cache: maven
-          # Disabling shallow clone is recommended for improving relevancy of reporting
-          fetch-depth: 0
+
       - name: Build
         run: mvn package -DskipTests=true
+
       - name: Test and Generate Sonar Report
-        run: mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=hoverla-bobocode_Bring
+        run: mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,12 @@
     <properties>
         <java.version>17</java.version>
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
+        <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
         <maven.jacoco.plugin.version>0.8.7</maven.jacoco.plugin.version>
-        <sonar.organization>hoverla-bobocode</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.organization>hoverla-bobocode</sonar.organization>
+        <sonar.projectKey>hoverla-bobocode_Bring</sonar.projectKey>
         <logback.version>1.2.11</logback.version>
         <lombok.version>1.18.24</lombok.version>
         <junit.version>5.8.2</junit.version>
@@ -77,6 +79,14 @@
                         <!-- to preserve method parameter names after compilation -->
                         <arg>-parameters</arg>
                     </compilerArgs>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven.resources.plugin.version}</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Hotfix includes:

1. Improvement of `bring-ci.yaml`
2. Addition of latest version of `maven-resources-plugin` to `pom.xml`
