### PR TITLE
Enhance @Bean and @Configuration classes validation, implement BeanDependencyNameResolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <lombok.version>1.18.24</lombok.version>
         <guava.version>31.1-jre</guava.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
+        <commons-collections.version>4.4</commons-collections.version>
         <reflections.version>0.10.2</reflections.version>
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.6.1</mockito.version>
@@ -52,6 +53,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections.version}</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/src/main/java/com/bobocode/hoverla/bring/annotation/Bean.java
+++ b/src/main/java/com/bobocode/hoverla/bring/annotation/Bean.java
@@ -38,5 +38,5 @@ public @interface Bean {
      * or other methods that require bean name.</p>
      *
      */
-    String name() default "";
+    String value() default "";
 }

--- a/src/main/java/com/bobocode/hoverla/bring/context/AbstractBeanDefinition.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/AbstractBeanDefinition.java
@@ -65,4 +65,10 @@ public abstract class AbstractBeanDefinition implements BeanDefinition {
     public Object getInstance() {
         return Objects.requireNonNull(instance, "Instance of %s has not been created yet".formatted(name));
     }
+
+    @Override
+    public boolean isPrimary() {
+        // TODO: implement and add javadoc in interface
+        return true;
+    }
 }

--- a/src/main/java/com/bobocode/hoverla/bring/context/ApplicationContextImpl.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/ApplicationContextImpl.java
@@ -94,11 +94,14 @@ public class ApplicationContextImpl implements ApplicationContext {
                 .stream()
                 .map(beanDefinition -> beanType.cast(beanDefinition.getInstance()))
                 .toList();
+
         if (beans.isEmpty()) {
             throw new NoSuchBeanException(NO_SUCH_BEAN_EXCEPTION_MESSAGE.formatted(beanType.getSimpleName()));
-        } else if (beans.size() > 1) {
+        }
+        if (beans.size() > 1) {
             throw new NoUniqueBeanException(NO_UNIQUE_BEAN_EXCEPTION_MESSAGE.formatted(beanType.getSimpleName(), beans.size()));
-        } else return beans.get(0);
+        }
+        return beans.get(0);
     }
 
     @Override
@@ -119,10 +122,10 @@ public class ApplicationContextImpl implements ApplicationContext {
         checkBeanName(beanName);
 
         Object bean = getBean(beanName);
-        if (bean.getClass().isAssignableFrom(beanType)) {
+        try {
             return beanType.cast(bean);
-        } else {
-            throw new NoSuchBeanException(NO_SUCH_BEAN_EXCEPTION_MESSAGE.formatted(beanName));
+        } catch (ClassCastException ex) {
+            throw new NoSuchBeanException(NO_SUCH_BEAN_EXCEPTION_MESSAGE.formatted(beanType.getName()));
         }
     }
 

--- a/src/main/java/com/bobocode/hoverla/bring/context/BeanAnnotationClassValidator.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/BeanAnnotationClassValidator.java
@@ -2,15 +2,19 @@ package com.bobocode.hoverla.bring.context;
 
 import com.bobocode.hoverla.bring.annotation.Bean;
 import com.bobocode.hoverla.bring.annotation.Inject;
+import com.bobocode.hoverla.bring.annotation.Qualifier;
 import com.bobocode.hoverla.bring.exception.BeanClassValidationException;
+import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.ListUtils;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -18,20 +22,31 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static java.lang.String.format;
-import static java.lang.reflect.Array.getLength;
-import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Validates classes annotated with {@link Bean @Bean} that were scanned by {@link BeanAnnotationScanner}.
  *
  * <p>Receives a {@link Set} of {@link Class} objects and performs type, instance fields and constructors checks.</p>
- *
- * <p>Validation ensures:
- * <br>1. Valid type of a {@link Class} object - see {@code UNSUPPORTED_TYPE_PREDICATE_MAP}.</br>
- * <br>2. Valid declared constructor - one constructor declaration allowed, plain constructors
- * are not mixed with constructors annotated with {@link Inject @Inject}.</br>
- * <br>3. Valid declared instance fields - fields annotated with {@link Inject @Inject} are neither {@code static} nor {@code final}.</br>
- * </p>
+ * Validation ensures:
+ * <ol>
+ *     <li>Valid type of a {@link Class} object.
+ *     <br>See {@link BeanAnnotationClassValidator#validateClass(Class)}</li>
+ *     <li>Valid declared constructor - one constructor declaration allowed, plain constructors are not
+ *     mixed with constructors annotated with {@link Inject @Inject}.
+ *     <br>See {@link BeanAnnotationClassValidator#validateConstructors(Class, List)}</li>
+ *     <li>Valid declared constructor parameters - there should be no parameters with duplicated {@link Qualifier @Qualifier} value
+ *     or parameters of the same type without {@link Qualifier @Qualifier}.
+ *     <br>See {@link BeanAnnotationClassValidator#validateConstructorParameters(List, List)}</li>
+ *     <li>Valid declared instance fields - fields annotated with {@link Inject @Inject}
+ *     are neither {@code static} nor {@code final}.
+ *     There should be no fields of the same type without {@link Qualifier @Qualifier} annotation.
+ *     There should be no fields with the same {@link Qualifier @Qualifier} value.</li>
+ *     <br>See {@link BeanAnnotationClassValidator#validateFields(Class, List)}
+ * </ol>
  *
  * @see Bean
  * @see Inject
@@ -55,7 +70,6 @@ public class BeanAnnotationClassValidator {
      *
      * @param beanClasses {@link Set} of scanned {@link Class} objects, returned by {@link BeanAnnotationScanner}.
      * @throws BeanClassValidationException when any validation constraint is violated.
-     *
      * @see BeanAnnotationScanner
      */
     public void validateBeanClasses(Set<Class<?>> beanClasses) {
@@ -71,9 +85,12 @@ public class BeanAnnotationClassValidator {
 
             if (!validationViolations.isEmpty()) {
                 log.error("Validation failed for class - {}", beanClassName);
+
                 int violationsAmount = validationViolations.size();
+                String formattedViolations = String.join(VIOLATION_MESSAGES_DELIMITER, validationViolations);
+
                 String exceptionMessage = format("Found %d validation errors for class %s: %n- %s",
-                        violationsAmount, beanClassName, constructExceptionMessage(validationViolations));
+                        violationsAmount, beanClassName, formattedViolations);
 
                 throw new BeanClassValidationException(exceptionMessage);
             }
@@ -92,29 +109,15 @@ public class BeanAnnotationClassValidator {
                 });
     }
 
-    private void validateFields(Class<?> beanClass, List<String> validationViolations) {
-        Field[] classFields = beanClass.getDeclaredFields();
-        List<Field> fieldsForInjection = getMembersMarkedWithInject(classFields);
-
-        log.trace("Found {} fields marked with @Inject", fieldsForInjection.size());
-        for (Field field : fieldsForInjection) {
-            String fieldName = field.getName();
-            int fieldModifiers = field.getModifiers();
-            if (Modifier.isFinal(fieldModifiers) || Modifier.isStatic(fieldModifiers)) {
-                validationViolations.add(format("Field marked with @Inject cannot be static/final - %s", fieldName));
-            }
-        }
-    }
-
     private void validateConstructors(Class<?> beanClass, List<String> validationViolations) {
-        Constructor<?>[] beanConstructors = beanClass.getConstructors();
-        log.trace("Overall number of constructors found - {}", beanConstructors.length);
-        if (isEmpty(beanConstructors)) {
+        List<Constructor<?>> beanConstructors = asList(beanClass.getConstructors());
+        log.trace("Overall number of constructors found - {}", beanConstructors.size());
+        if (beanConstructors.isEmpty()) {
             validationViolations.add("Class has no public constructors");
             return;
         }
 
-        List<Constructor<?>> injectionConstructors = getMembersMarkedWithInject(beanConstructors);
+        List<Constructor<?>> injectionConstructors = getElementsAnnotatedWith(beanConstructors, Inject.class);
         if (!injectionConstructors.isEmpty()) {
             validateInjectionConstructors(injectionConstructors, validationViolations);
         } else {
@@ -138,33 +141,114 @@ public class BeanAnnotationClassValidator {
 
         if (beanConstructor.getParameterCount() == 0) {
             validationViolations.add("@Inject constructor has no parameters");
+        } else {
+            List<Parameter> constructorParameters = asList(beanConstructor.getParameters());
+            validateConstructorParameters(constructorParameters, validationViolations);
         }
     }
 
-    private void validatePlainConstructors(Constructor<?>[] beanConstructors, List<String> validationViolations) {
-        int constructorAmount = getLength(beanConstructors);
-        log.trace("Found {} plain constructors", constructorAmount);
-        if (constructorAmount > 1) {
-            validationViolations.add(format("Class has %d plain constructors. Unable to pick up one", constructorAmount));
+    private void validatePlainConstructors(List<Constructor<?>> beanConstructors, List<String> validationViolations) {
+        if (beanConstructors.size() > 1) {
+            validationViolations.add(format("Class has %d plain constructors. Unable to pick up one", beanConstructors.size()));
             return;
         }
-
-        Constructor<?> beanConstructor = beanConstructors[0];
+        Constructor<?> beanConstructor = beanConstructors.get(0);
         log.trace("Single plain constructor found - {}", beanConstructor);
 
         int parameterCount = beanConstructor.getParameterCount();
         if (parameterCount > 0) {
+            List<Parameter> constructorParameters = asList(beanConstructor.getParameters());
             log.trace("Constructor has {} parameters - will be used for injection", parameterCount);
+            validateConstructorParameters(constructorParameters, validationViolations);
         }
     }
 
-    private <M extends AnnotatedElement> List<M> getMembersMarkedWithInject(M[] classMembers) {
-        return Arrays.stream(classMembers)
-                .filter(member -> member.isAnnotationPresent(Inject.class))
-                .toList();
+    private void validateConstructorParameters(List<Parameter> constructorParameters, List<String> validationViolations) {
+        log.trace("Validating constructor parameters");
+        List<Parameter> qualifiedParameters = getElementsAnnotatedWith(constructorParameters, Qualifier.class);
+        List<Parameter> nonQualifiedParameters = ListUtils.removeAll(constructorParameters, qualifiedParameters);
+
+        validateQualifiedParameters(qualifiedParameters, validationViolations);
+        validateNonQualifiedParameters(nonQualifiedParameters, validationViolations);
     }
 
-    private String constructExceptionMessage(List<String> validationViolations) {
-        return String.join(VIOLATION_MESSAGES_DELIMITER, validationViolations);
+    private void validateQualifiedParameters(List<Parameter> qualifiedParameters, List<String> validationViolations) {
+        Map<String, List<String>> parametersWithSameQualifier = qualifiedParameters.stream()
+                .collect(groupingBy(p -> p.getAnnotation(Qualifier.class).value(), mapping(Parameter::getName, toList())));
+
+        Maps.filterValues(parametersWithSameQualifier, names -> names.size() > 1)
+                .forEach((qualifier, paramNames) -> validationViolations.add(
+                        format("Found several constructor parameters with same @Qualifier value `%s` - %s",
+                                qualifier, paramNames))
+                );
+    }
+
+    private void validateNonQualifiedParameters(List<Parameter> nonQualifiedParameters,
+                                                List<String> validationViolations) {
+        Map<Class<?>, List<String>> parametersWithSameType = nonQualifiedParameters.stream()
+                .collect(groupingBy(Parameter::getType, mapping(Parameter::getName, toList())));
+
+        Maps.filterValues(parametersWithSameType, paramNames -> paramNames.size() > 1)
+                .forEach((type, fieldNames) -> validationViolations.add(
+                        format("Found several constructor parameters of type %s without @Qualifier - %s",
+                                type.getName(), fieldNames))
+                );
+    }
+
+    private void validateFields(Class<?> beanClass, List<String> validationViolations) {
+        List<Field> classFields = asList(beanClass.getDeclaredFields());
+
+        List<Field> fieldsForInjection = getElementsAnnotatedWith(classFields, Inject.class);
+        if (fieldsForInjection.isEmpty()) {
+            log.trace("No fields marked with @Inject found - aborting field validation");
+            return;
+        }
+
+        log.trace("Found {} fields marked with @Inject", fieldsForInjection.size());
+
+        validateFieldsModifiers(fieldsForInjection, validationViolations);
+
+        List<Field> qualifiedFields = getElementsAnnotatedWith(fieldsForInjection, Qualifier.class);
+        List<Field> nonQualifiedFields = ListUtils.removeAll(fieldsForInjection, qualifiedFields);
+
+        validateQualifiedFields(qualifiedFields, validationViolations);
+        validateNonQualifiedFields(nonQualifiedFields, validationViolations);
+    }
+
+    private void validateQualifiedFields(List<Field> qualifiedFields, List<String> validationViolations) {
+        Map<String, List<String>> fieldsWithSameQualifier = qualifiedFields.stream()
+                .collect(groupingBy(f -> f.getAnnotation(Qualifier.class).value(), mapping(Field::getName, toList())));
+
+        Maps.filterValues(fieldsWithSameQualifier, fieldNames -> fieldNames.size() > 1)
+                .forEach((qualifier, fieldNames) -> validationViolations.add(
+                        format("Found several fields with same @Qualifier value `%s` - %s", qualifier, fieldNames))
+                );
+    }
+
+    private void validateNonQualifiedFields(List<Field> nonQualifiedFields, List<String> validationViolations) {
+        Map<Class<?>, List<String>> fieldsWithSameType = nonQualifiedFields.stream()
+                .collect(groupingBy(Field::getType, mapping(Field::getName, toList())));
+
+        Maps.filterValues(fieldsWithSameType, fieldNames -> fieldNames.size() > 1)
+                .forEach((type, fieldNames) -> validationViolations.add(
+                        format("Found several fields of type %s without @Qualifier - %s", type.getName(), fieldNames))
+                );
+    }
+
+    private void validateFieldsModifiers(List<Field> fieldsForInjection, List<String> validationViolations) {
+        for (Field field : fieldsForInjection) {
+            String fieldName = field.getName();
+            int fieldModifiers = field.getModifiers();
+            if (Modifier.isFinal(fieldModifiers) || Modifier.isStatic(fieldModifiers)) {
+                validationViolations.add(format("Field marked with @Inject cannot be static/final - %s", fieldName));
+            }
+        }
+    }
+
+    private <E extends AnnotatedElement> List<E> getElementsAnnotatedWith(List<E> elements,
+                                                                          Class<? extends Annotation> annotationClass) {
+        return elements.stream()
+                .filter(member -> member.isAnnotationPresent(annotationClass))
+                .toList();
     }
 }

--- a/src/main/java/com/bobocode/hoverla/bring/context/BeanDefinition.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/BeanDefinition.java
@@ -62,4 +62,5 @@ public interface BeanDefinition {
      */
     Object getInstance();
 
+    boolean isPrimary();
 }

--- a/src/main/java/com/bobocode/hoverla/bring/context/BeanDependencyNameResolver.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/BeanDependencyNameResolver.java
@@ -1,0 +1,63 @@
+package com.bobocode.hoverla.bring.context;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Table;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.Map;
+
+@Slf4j
+public class BeanDependencyNameResolver {
+
+    public void resolveDependencyNames(Table<String, Class<?>, BeanDefinition> beanDefinitions) {
+        log.debug("Trying to resolve real dependency names for each bean definition before initialization");
+        for (BeanDefinition beanDefinition : beanDefinitions.values()) {
+            Map<String, Class<?>> beanDependencies = beanDefinition.dependencies();
+
+            log.trace("Verifying names of {} dependencies of bean definition {} - {} ",
+                    beanDependencies.size(), beanDefinition.name(), beanDefinition.type().getName());
+
+            beanDependencies.entrySet()
+                    .iterator() // using Iterator to avoid ConcurrentModificationException
+                    .forEachRemaining(entry -> resolveDependencyName(entry, beanDependencies, beanDefinitions));
+        }
+    }
+
+    private void resolveDependencyName(Map.Entry<String, Class<?>> targetDependency,
+                                       Map<String, Class<?>> beanDependencies,
+                                       Table<String, Class<?>, BeanDefinition> beanDefinitions) {
+        String dependencyName = targetDependency.getKey();
+        Class<?> dependencyType = targetDependency.getValue();
+
+        if (dependencyName.equals(dependencyType.getName())) { // mean dependency has no @Qualifier annotation
+            log.trace("Found dependency with unspecified name: {}. Trying to find matching bean definition by type: {} ",
+                    dependencyName, dependencyType.getName());
+
+            Map<String, BeanDefinition> definitionsByType = beanDefinitions.column(dependencyType);
+            BeanDefinition matchingDependency = findMatchingDependency(definitionsByType);
+            log.trace("Matching bean definition found: {} - {}", matchingDependency.name(), matchingDependency.type().getName());
+
+            String newDependencyName = matchingDependency.name();
+            if (newDependencyName.equals(dependencyName)) {
+                log.trace("Matching bean definition has same unspecified name. Aborting replacement");
+                return;
+            }
+
+            Class<?> oldDependencyType = beanDependencies.remove(dependencyName);
+            beanDependencies.put(newDependencyName, oldDependencyType);
+            log.trace("Replaced unspecified name {} with {}", dependencyName, newDependencyName);
+        }
+    }
+
+    private BeanDefinition findMatchingDependency(Map<String, BeanDefinition> definitionsByType) {
+        if (definitionsByType.size() > 1) { // need to search for primary bean
+            log.trace("Found more than 1 bean definitions by type. Will search for single primary bean");
+            // we assume that at this point we should have only one primary bean
+            // see BeanDefinitionValidator.java
+            Map<String, BeanDefinition> primaryBeanMap = Maps.filterValues(definitionsByType, BeanDefinition::isPrimary);
+            return CollectionUtils.get(primaryBeanMap, 0).getValue();
+        }
+        return CollectionUtils.get(definitionsByType, 0).getValue();
+    }
+}

--- a/src/main/java/com/bobocode/hoverla/bring/context/BeanInitializer.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/BeanInitializer.java
@@ -2,6 +2,7 @@ package com.bobocode.hoverla.bring.context;
 
 import com.bobocode.hoverla.bring.annotation.Bean;
 import com.google.common.collect.Table;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -17,7 +18,10 @@ import java.util.Collection;
  * @see BeanDefinition
  */
 @Slf4j
+@RequiredArgsConstructor
 public class BeanInitializer {
+
+    private final BeanDependencyNameResolver dependencyNameResolver;
 
     /**
      * Triggers instantiation of all beans by passing their required dependencies.
@@ -26,6 +30,8 @@ public class BeanInitializer {
      */
     public void initialize(Table<String, Class<?>, BeanDefinition> beanDefinitionsTable) {
         log.debug("Bean initialization started");
+        dependencyNameResolver.resolveDependencyNames(beanDefinitionsTable);
+
         Collection<BeanDefinition> beanDefinitions = beanDefinitionsTable.values();
         beanDefinitions.forEach(beanDefinition -> doInitialize(beanDefinition, beanDefinitionsTable));
     }
@@ -36,7 +42,7 @@ public class BeanInitializer {
             return;
         }
         String beanName = definitionToInitialize.name();
-        log.trace("Resolving dependencies for bean definition: {}", beanName);
+        log.trace("Initializing bean definition - {}", beanName);
 
         BeanDefinition[] beanDependencies = getBeanDependencies(definitionToInitialize, beanDefinitionsTable);
         int numberOfDependencies = ArrayUtils.getLength(beanDependencies);

--- a/src/main/java/com/bobocode/hoverla/bring/context/ClassBasedBeanDefinition.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/ClassBasedBeanDefinition.java
@@ -88,7 +88,7 @@ public class ClassBasedBeanDefinition extends AbstractBeanDefinition {
      */
     private String resolveName(Class<?> beanClass) {
         Bean annotation = beanClass.getAnnotation(Bean.class);
-        String beanName = annotation.name();
+        String beanName = annotation.value();
         if (isBlank(beanName)) {
             return beanClass.getName();
         }

--- a/src/main/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinition.java
+++ b/src/main/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinition.java
@@ -87,7 +87,7 @@ public class ConfigBasedBeanDefinition extends AbstractBeanDefinition {
      */
     private String resolveName(Method beanMethod) {
         Bean annotation = beanMethod.getAnnotation(Bean.class);
-        String beanName = annotation.name();
+        String beanName = annotation.value();
         if (beanName.isEmpty()) {
             return beanMethod.getName();
         }
@@ -152,6 +152,6 @@ public class ConfigBasedBeanDefinition extends AbstractBeanDefinition {
         if (parameter.isAnnotationPresent(Qualifier.class)) {
             return parameter.getAnnotation(Qualifier.class).value();
         }
-        return parameter.getName();
+        return parameter.getType().getName();
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/BringApplicationTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/BringApplicationTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BringApplicationTest {
+
     private final String EXCEPTION_MESSAGE = "Argument [packagesToScan] must contain at least one not null and not empty element";
 
     @ParameterizedTest(name = "Throws exception when null or empty package name was provided")

--- a/src/test/java/com/bobocode/hoverla/bring/context/BeanAnnotationClassValidatorTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/context/BeanAnnotationClassValidatorTest.java
@@ -8,9 +8,13 @@ import com.bobocode.hoverla.bring.test.subject.bean.util.TestBean4;
 import com.bobocode.hoverla.bring.test.subject.bean.util.TestBean5;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.constructor.TestBeanWithInjectConstructors;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.constructor.TestBeanWithPlainConstructors;
+import com.bobocode.hoverla.bring.test.subject.validation.bean.constructor.TestBeanWithSameParameterQualifiers;
+import com.bobocode.hoverla.bring.test.subject.validation.bean.constructor.TestBeanWithSameTypeParameters;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.constructor.TestBeanWithSingleInjectConstructor;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.constructor.TestBeanWithoutConstructors;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.field.TestBeanWithFinalInjectFields;
+import com.bobocode.hoverla.bring.test.subject.validation.bean.field.TestBeanWithSameTypeInjectFields;
+import com.bobocode.hoverla.bring.test.subject.validation.bean.field.TestBeanWithSameFieldQualifiers;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.field.TestBeanWithStaticInjectFields;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.type.AbstractTestBean;
 import com.bobocode.hoverla.bring.test.subject.validation.bean.type.EnumTestBean;
@@ -51,7 +55,11 @@ class BeanAnnotationClassValidatorTest {
                 Arguments.of(TestBeanWithSingleInjectConstructor.class, "@Inject constructor has no parameters"),
                 Arguments.of(TestBeanWithInjectConstructors.class, "Class has 2 constructors marked with @Inject. Unable to pick up one"),
                 Arguments.of(TestBeanWithStaticInjectFields.class, "Field marked with @Inject cannot be static/final"),
-                Arguments.of(TestBeanWithFinalInjectFields.class, "Field marked with @Inject cannot be static/final")
+                Arguments.of(TestBeanWithFinalInjectFields.class, "Field marked with @Inject cannot be static/final"),
+                Arguments.of(TestBeanWithSameTypeInjectFields.class, "Found several fields of type java.lang.Integer without @Qualifier"),
+                Arguments.of(TestBeanWithSameFieldQualifiers.class, "Found several fields with same @Qualifier value `string`"),
+                Arguments.of(TestBeanWithSameTypeParameters.class, "Found several constructor parameters of type java.lang.String without @Qualifier"),
+                Arguments.of(TestBeanWithSameParameterQualifiers.class, "Found several constructor parameters with same @Qualifier value `int`")
         );
     }
 

--- a/src/test/java/com/bobocode/hoverla/bring/context/BeanConfigurationClassValidatorTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/context/BeanConfigurationClassValidatorTest.java
@@ -67,7 +67,13 @@ class BeanConfigurationClassValidatorTest {
                         "Doesn't allow method marked as @Bean to be protected"),
                 Arguments.of(
                         "staticMethod method must not be static",
-                        "Doesn't allow method marked as @Bean to be static")
+                        "Doesn't allow method marked as @Bean to be static"),
+                Arguments.of("Found several method parameters with same @Qualifier value `int`",
+                        "Doesn't allow method marked as @Bean to have parameters with same @Qualifier"),
+                Arguments.of(
+                        "Found several method parameters of type java.lang.Integer without @Qualifier",
+                        "Doesn't allow method marked as @Bean to have parameters of same type without @Qualifier"
+                )
         );
     }
 

--- a/src/test/java/com/bobocode/hoverla/bring/context/BeanDependencyNameResolverTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/context/BeanDependencyNameResolverTest.java
@@ -1,0 +1,77 @@
+package com.bobocode.hoverla.bring.context;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import org.assertj.core.util.Maps;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BeanDependencyNameResolverTest {
+
+    private BeanDependencyNameResolver dependencyNameResolver;
+
+    @BeforeEach
+    void setUp() {
+        dependencyNameResolver = new BeanDependencyNameResolver();
+    }
+
+    @Test
+    @DisplayName("Replaces default dependency names with their custom")
+    void replacesDefaultNameToCustom() {
+        BeanDefinition dependency = prepareDefinition("int1", Integer.class, emptyMap());
+        Map<String, Class<?>> dependencies = Maps.newHashMap(Integer.class.getName(), Integer.class);
+        BeanDefinition dependent = prepareDefinition("bean", Object.class, dependencies);
+        Table<String, Class<?>, BeanDefinition> beanTable = HashBasedTable.create();
+        beanTable.put(dependency.name(), dependency.type(), dependency);
+        beanTable.put(dependent.name(), dependent.type(), dependent);
+
+        dependencyNameResolver.resolveDependencyNames(beanTable);
+
+        Map<String, Class<?>> resolvedDependencies = dependent.dependencies();
+
+        assertThat(resolvedDependencies)
+                .containsEntry(dependency.name(), dependency.type())
+                .doesNotContainEntry(Integer.class.getName(), Integer.class);
+    }
+
+    @Test
+    @DisplayName("Replaces default dependency names with primary bean custom when there are more than 1 bean of the same type")
+    void replacesDefaultNameToPrimaryBeanName() {
+        BeanDefinition nonPrimaryDependency = prepareDefinition("int1", Integer.class, Map.of());
+        BeanDefinition primaryDependency = prepareDefinition("int2", Integer.class, emptyMap());
+        when(primaryDependency.isPrimary()).thenReturn(true);
+        Map<String, Class<?>> dependencies = Maps.newHashMap(Integer.class.getName(), Integer.class);
+        BeanDefinition dependent = prepareDefinition("bean", Object.class, dependencies);
+
+        Table<String, Class<?>, BeanDefinition> beanTable = HashBasedTable.create();
+        beanTable.put(nonPrimaryDependency.name(), nonPrimaryDependency.type(), nonPrimaryDependency);
+        beanTable.put(primaryDependency.name(), primaryDependency.type(), primaryDependency);
+        beanTable.put(dependent.name(), dependent.type(), dependent);
+
+        dependencyNameResolver.resolveDependencyNames(beanTable);
+
+        Map<String, Class<?>> resolvedDependencies = dependent.dependencies();
+
+        assertThat(resolvedDependencies)
+                .containsEntry(primaryDependency.name(), primaryDependency.type())
+                .doesNotContainEntry(Integer.class.getName(), Integer.class)
+                .doesNotContainEntry(nonPrimaryDependency.name(), nonPrimaryDependency.type());
+    }
+
+    private BeanDefinition prepareDefinition(String beanName, Class<?> type, Map<String, Class<?>> dependencyMap) {
+        BeanDefinition beanDefinition = mock(BeanDefinition.class);
+        doReturn(type).when(beanDefinition).type();
+        when(beanDefinition.name()).thenReturn(beanName);
+        when(beanDefinition.dependencies()).thenReturn(dependencyMap);
+        return beanDefinition;
+    }
+}

--- a/src/test/java/com/bobocode/hoverla/bring/context/BeanInitializerTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/context/BeanInitializerTest.java
@@ -3,6 +3,7 @@ package com.bobocode.hoverla.bring.context;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,10 +29,19 @@ class BeanInitializerTest {
     private static final String BD3 = "beanDef3";
     private static final String BD4 = "beanDef4";
 
+    private BeanInitializer beanInitializer;
+    private BeanDependencyNameResolver dependencyNameResolver;
+
+    @BeforeEach
+    void setUp() {
+        dependencyNameResolver = mock(BeanDependencyNameResolver.class);
+        beanInitializer = new BeanInitializer(dependencyNameResolver);
+    }
+
     @Test
     @DisplayName("Initialization test. Verifies that 'instance' method of BeanDefinition is called with correct dependencies")
     void testInitialize() {
-        //Given
+        // Given
         BeanDefinition beanDef1 = prepareDefinition(BD1, BD2, BD3);
         BeanDefinition beanDef2 = prepareDefinition(BD2, BD3, BD4);
         BeanDefinition beanDef3 = prepareDefinition(BD3, BD4);
@@ -51,12 +61,12 @@ class BeanInitializerTest {
                 beanDef4, new BeanDefinition[0]
         );
 
-        BeanInitializer beanInitializer = new BeanInitializer();
-
-        //When
+        // When
         beanInitializer.initialize(beanDefinitionTable);
 
-        //Then
+        // Then
+        verify(dependencyNameResolver).resolveDependencyNames(beanDefinitionTable);
+
         for (BeanDefinition beanDefinition : beanDefinitionTable.values()) {
             ArgumentCaptor<BeanDefinition> definitionCaptor = ArgumentCaptor.forClass(BeanDefinition.class);
 
@@ -70,7 +80,7 @@ class BeanInitializerTest {
         }
     }
 
-    private static BeanDefinition prepareDefinition(String beanDefinitionName, String... dependencyNames) {
+    private BeanDefinition prepareDefinition(String beanDefinitionName, String... dependencyNames) {
         BeanDefinition beanDefinition = mock(BeanDefinition.class);
         doReturn(BeanDefinition.class).when(beanDefinition).type();
         when(beanDefinition.name()).thenReturn(beanDefinitionName);
@@ -82,7 +92,7 @@ class BeanInitializerTest {
         when(beanDefinition.dependencies()).thenReturn(dependencies);
 
         // isInstantiated() method of BeanDefinition should return true only when instantiate(...) method was called.
-        // To mock such behavior we basically say: "when instantiate -> then isInstantiated() should return true"
+        // To mock such behavior we basically say: "when instantiate() -> then isInstantiated() should return true"
         Supplier<?> instantiateAnswerSupplier = () -> when(beanDefinition.isInstantiated()).thenReturn(true);
         doAnswer(ignore -> instantiateAnswerSupplier.get()).when(beanDefinition).instantiate(any());
 

--- a/src/test/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinitionTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/context/ConfigBasedBeanDefinitionTest.java
@@ -70,7 +70,7 @@ class ConfigBasedBeanDefinitionTest {
         when(firstDependency.getInstance()).thenReturn(1);
         BeanDefinition secondDependency = mock(BeanDefinition.class);
         when(secondDependency.getInstance()).thenReturn("string");
-        Map<String, Class<?>> dependencies = Map.of("num", int.class, "testParamName", String.class);
+        Map<String, Class<?>> dependencies = Map.of(int.class.getName(), int.class, "testParamName", String.class);
 
         BeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);
 
@@ -122,7 +122,7 @@ class ConfigBasedBeanDefinitionTest {
 
         BeanDefinition firstDependency = mock(BeanDefinition.class);
         when(firstDependency.getInstance()).thenReturn((byte) 1);
-        when(firstDependency.name()).thenReturn("num");
+        when(firstDependency.name()).thenReturn(byte.class.getName());
         doReturn(byte.class).when(firstDependency).type();
 
         BeanDefinition secondDependency = mock(BeanDefinition.class);
@@ -132,7 +132,7 @@ class ConfigBasedBeanDefinitionTest {
 
         BeanDefinition thirdDependency = mock(BeanDefinition.class);
         when(thirdDependency.getInstance()).thenReturn("anotherString");
-        when(thirdDependency.name()).thenReturn("anotherValue");
+        when(thirdDependency.name()).thenReturn(String.class.getName());
         doReturn(String.class).when(thirdDependency).type();
 
         ConfigBasedBeanDefinition beanDefinition = new ConfigBasedBeanDefinition(testBeanConfig, method);

--- a/src/test/java/com/bobocode/hoverla/bring/integration/BringPositiveIntegrationTest.java
+++ b/src/test/java/com/bobocode/hoverla/bring/integration/BringPositiveIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BringPositiveIntegrationTest {
 
     private static final String PACKAGE = "com.bobocode.hoverla.bring.integration";
+
     private ApplicationContext applicationContext;
 
     @BeforeEach

--- a/src/test/java/com/bobocode/hoverla/bring/integration/beans/TestBean1.java
+++ b/src/test/java/com/bobocode/hoverla/bring/integration/beans/TestBean1.java
@@ -2,6 +2,6 @@ package com.bobocode.hoverla.bring.integration.beans;
 
 import com.bobocode.hoverla.bring.annotation.Bean;
 
-@Bean(name = "testBean1")
+@Bean("testBean1")
 public class TestBean1 {
 }

--- a/src/test/java/com/bobocode/hoverla/bring/integration/config/TestBeansConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/integration/config/TestBeansConfig.java
@@ -7,7 +7,7 @@ import com.bobocode.hoverla.bring.integration.beans.TestBean1;
 import com.bobocode.hoverla.bring.integration.beans.TestBean2;
 
 @Configuration
-public class BeansConfig {
+public class TestBeansConfig {
 
     @Bean
     public TestBean1 testBean1FromConfig() {

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/bean/util/TestBean1.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/bean/util/TestBean1.java
@@ -3,7 +3,7 @@ package com.bobocode.hoverla.bring.test.subject.bean.util;
 import com.bobocode.hoverla.bring.annotation.Bean;
 import lombok.RequiredArgsConstructor;
 
-@Bean(name = "testBean1")
+@Bean("testBean1")
 @RequiredArgsConstructor
 public class TestBean1 {
 

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/config/TestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/config/TestBeanConfig.java
@@ -12,7 +12,7 @@ public class TestBeanConfig {
         return "instance";
     }
 
-    @Bean(name = "beanName")
+    @Bean("beanName")
     public String beanWithNameInAnnotation() {
         return "instance";
     }

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/constructor/TestBeanWithSameParameterQualifiers.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/constructor/TestBeanWithSameParameterQualifiers.java
@@ -1,0 +1,17 @@
+package com.bobocode.hoverla.bring.test.subject.validation.bean.constructor;
+
+import com.bobocode.hoverla.bring.annotation.Bean;
+import com.bobocode.hoverla.bring.annotation.Qualifier;
+
+@Bean
+public class TestBeanWithSameParameterQualifiers {
+
+    private final Integer integerOne;
+    private final Integer integerTwo;
+
+    public TestBeanWithSameParameterQualifiers(@Qualifier("int") Integer integerOne,
+                                               @Qualifier("int") Integer integerTwo) {
+        this.integerOne = integerOne;
+        this.integerTwo = integerTwo;
+    }
+}

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/constructor/TestBeanWithSameTypeParameters.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/constructor/TestBeanWithSameTypeParameters.java
@@ -1,0 +1,15 @@
+package com.bobocode.hoverla.bring.test.subject.validation.bean.constructor;
+
+import com.bobocode.hoverla.bring.annotation.Bean;
+
+@Bean
+public class TestBeanWithSameTypeParameters {
+
+    private final String stringOne;
+    private final String stringTwo;
+
+    public TestBeanWithSameTypeParameters(String stringOne, String stringTwo) {
+        this.stringOne = stringOne;
+        this.stringTwo = stringTwo;
+    }
+}

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/field/TestBeanWithSameFieldQualifiers.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/field/TestBeanWithSameFieldQualifiers.java
@@ -1,0 +1,18 @@
+package com.bobocode.hoverla.bring.test.subject.validation.bean.field;
+
+import com.bobocode.hoverla.bring.annotation.Bean;
+import com.bobocode.hoverla.bring.annotation.Inject;
+import com.bobocode.hoverla.bring.annotation.Qualifier;
+
+@Bean
+public class TestBeanWithSameFieldQualifiers {
+
+    @Inject
+    @Qualifier("string")
+    private String firstString;
+
+    @Inject
+    @Qualifier("string")
+    private String secondString;
+
+}

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/field/TestBeanWithSameTypeInjectFields.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/bean/field/TestBeanWithSameTypeInjectFields.java
@@ -1,0 +1,15 @@
+package com.bobocode.hoverla.bring.test.subject.validation.bean.field;
+
+import com.bobocode.hoverla.bring.annotation.Bean;
+import com.bobocode.hoverla.bring.annotation.Inject;
+
+@Bean
+public class TestBeanWithSameTypeInjectFields {
+
+    @Inject
+    private Integer firstInteger;
+
+    @Inject
+    private Integer secondInteger;
+
+}

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/EnumTestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/EnumTestBeanConfig.java
@@ -3,12 +3,14 @@ package com.bobocode.hoverla.bring.test.subject.validation.config;
 import com.bobocode.hoverla.bring.annotation.Bean;
 import com.bobocode.hoverla.bring.annotation.Configuration;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 @Configuration
 public enum EnumTestBeanConfig {
     ELEMENT;
 
     @Bean
     public String bean() {
-        return "";
+        return EMPTY;
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/InnerClassTestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/InnerClassTestBeanConfig.java
@@ -3,13 +3,15 @@ package com.bobocode.hoverla.bring.test.subject.validation.config;
 import com.bobocode.hoverla.bring.annotation.Bean;
 import com.bobocode.hoverla.bring.annotation.Configuration;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 public class InnerClassTestBeanConfig {
 
     @Configuration
     public class InnerTestBeanConfig {
         @Bean
         public String bean() {
-            return "";
+            return EMPTY;
         }
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/InterfaceTestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/InterfaceTestBeanConfig.java
@@ -3,10 +3,12 @@ package com.bobocode.hoverla.bring.test.subject.validation.config;
 import com.bobocode.hoverla.bring.annotation.Bean;
 import com.bobocode.hoverla.bring.annotation.Configuration;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 @Configuration
 public interface InterfaceTestBeanConfig {
     @Bean
     static String bean() {
-        return "";
+        return EMPTY;
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/InvalidMethodsTestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/InvalidMethodsTestBeanConfig.java
@@ -2,27 +2,40 @@ package com.bobocode.hoverla.bring.test.subject.validation.config;
 
 import com.bobocode.hoverla.bring.annotation.Bean;
 import com.bobocode.hoverla.bring.annotation.Configuration;
+import com.bobocode.hoverla.bring.annotation.Qualifier;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Configuration
 public class InvalidMethodsTestBeanConfig {
 
     @Bean
     public static String staticMethod() {
-        return "";
+        return EMPTY;
     }
 
     @Bean
     private String privateMethod() {
-        return "";
+        return EMPTY;
     }
 
     @Bean
     String packagePrivateMethod() {
-        return "";
+        return EMPTY;
     }
 
     @Bean
     protected String protectedMethod() {
-        return "";
+        return EMPTY;
+    }
+
+    @Bean
+    public String sameParametersTypeMethod(Integer integerOne, Integer integerTwo) {
+        return EMPTY;
+    }
+
+    @Bean
+    public String sameQualifiersMethod(@Qualifier("int") Integer integerOne, @Qualifier("int") Integer integerTwo) {
+        return EMPTY;
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/RecordTestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/RecordTestBeanConfig.java
@@ -2,10 +2,12 @@ package com.bobocode.hoverla.bring.test.subject.validation.config;
 
 import com.bobocode.hoverla.bring.annotation.Bean;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 public record RecordTestBeanConfig() {
 
     @Bean
     public String bean() {
-        return "";
+        return EMPTY;
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/TestBeanConfigWithoutDefaultConstructor.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/TestBeanConfigWithoutDefaultConstructor.java
@@ -3,6 +3,8 @@ package com.bobocode.hoverla.bring.test.subject.validation.config;
 import com.bobocode.hoverla.bring.annotation.Bean;
 import com.bobocode.hoverla.bring.annotation.Configuration;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 @Configuration
 public class TestBeanConfigWithoutDefaultConstructor {
 
@@ -16,6 +18,6 @@ public class TestBeanConfigWithoutDefaultConstructor {
 
     @Bean
     public String bean() {
-        return "";
+        return EMPTY;
     }
 }

--- a/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/ValidTestBeanConfig.java
+++ b/src/test/java/com/bobocode/hoverla/bring/test/subject/validation/config/ValidTestBeanConfig.java
@@ -7,16 +7,18 @@ import com.bobocode.hoverla.bring.annotation.Qualifier;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 @Configuration
 public class ValidTestBeanConfig {
 
     @Bean
     public String beam1() {
-        return "";
+        return EMPTY;
     }
 
     public String notBean() {
-        return "";
+        return EMPTY;
     }
 
     @Bean


### PR DESCRIPTION
### Description:
1. Enhance validation of component classes (see corresponding javadocs)
2. Implement resolver for dependency names - for situations when dependent bean definition does not have @Qualifier but has @Bean with a name specified
3. Add initial support for primary beans

### Ticket: <https://trello.com/c/e6Vf5HUa, https://trello.com/c/LlyJnJsa>